### PR TITLE
尝试修复保存uuid时的bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,12 @@ subprojects {
         //implementation("cn.evole.config:AtomConfig-Yaml:0.2.0")
         compileOnly ("org.projectlombok:lombok:1.18.24")
         annotationProcessor ("org.projectlombok:lombok:1.18.24")
+        testCompileOnly 'org.projectlombok:lombok:1.18.24'
+        testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
     }
 
     tasks.withType(JavaCompile).configureEach {
-    
+
         it.options.encoding = 'UTF-8'
         it.options.getRelease().set(17)
     }
@@ -99,3 +101,4 @@ subprojects {
         enabled = false
     }
 }
+

--- a/common/src/main/java/committee/nova/mods/novalogin/mixins/ServerLoginPktMixin.java
+++ b/common/src/main/java/committee/nova/mods/novalogin/mixins/ServerLoginPktMixin.java
@@ -131,10 +131,11 @@ public abstract class ServerLoginPktMixin {
             if (code == HttpURLConnection.HTTP_OK) {
                 var re = GSON.fromJson(JsonParser.parseString(msg), MojangResponse.class);
                 StringBuilder uuid = new StringBuilder(re.getId());
-                uuid.insert(8,"-");
-                uuid.insert(12,"-");
-                uuid.insert(16,"-");
                 uuid.insert(20,"-");
+                uuid.insert(16,"-");
+                uuid.insert(12,"-");
+                uuid.insert(8,"-");
+
 
                 LOGGER.info("Player {} has a Mojang account, use online UUID {}", playerName, uuid);
 

--- a/common/src/main/java/committee/nova/mods/novalogin/models/User.java
+++ b/common/src/main/java/committee/nova/mods/novalogin/models/User.java
@@ -1,7 +1,6 @@
 package committee.nova.mods.novalogin.models;
 
 import lombok.Setter;
-
 /**
  * LoginPlayer
  *

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -91,6 +91,7 @@ tasks.withType(JavaCompile).configureEach {
     source(project(":common").sourceSets.main.allSource)
 }
 tasks.withType(Javadoc).configureEach {
+    enabled = false
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
     source(project(":common").sourceSets.main.allJava)
 }


### PR DESCRIPTION
作者你好，我正在尝试开发一个服务器插件，其中需要监听`PlayerJoinEvent`并获取进入游戏的玩家`uuid`和`name`，然后通过 Mojang api 验证该玩家是否为正版用户，苦于正版玩家进入关闭了正版验证的服务器时，无法携带Mojang的`uuid`的问题，幸而发现`NovaLogin`可以修复此问题，但在试验中发现`uuid`处理后总是缺失了几位数，一番折腾后发现对`uuid`的连字符插入似乎有些许问题.....故尝试修复之。
顺便请教一下修复正版玩家携带`uuid`问题的思路（第一次接触，代码看不太明白 :>）